### PR TITLE
Stop redis key leaking

### DIFF
--- a/faye-redis.js
+++ b/faye-redis.js
@@ -120,9 +120,9 @@ Engine.prototype = {
   },
 
   subscribe: function(clientId, channel, callback, context) {
+    var self = this;
     var multi = self._redis.multi();
     var time = new Date().getTime();
-    var self = this;
 
     multi.sadd(this._ns + '/clients/' + clientId + '/channels', channel, function(error, added) {
       if (added === 1) self._server.trigger('subscribe', clientId, channel);

--- a/package.json
+++ b/package.json
@@ -1,21 +1,36 @@
-{ "name"            : "faye-redis"
-, "description"     : "Redis backend engine for Faye"
-, "homepage"        : "http://github.com/faye/faye-redis-node"
-, "author"          : "James Coglan <jcoglan@gmail.com> (http://jcoglan.com/)"
-, "keywords"        : ["pubsub", "bayeux"]
-, "license"         : "MIT"
-
-, "version"         : "0.2.0"
-, "engines"         : {"node": ">=0.4.0"}
-, "main"            : "./faye-redis"
-, "dependencies"    : {"redis": "2.8.0"}
-, "devDependencies" : {"jstest": ""}
-
-, "scripts"         : {"test": "node spec/runner.js"}
-
-, "bugs"            : "http://github.com/faye/faye-redis-node/issues"
-
-, "repository"      : { "type"  : "git"
-                      , "url"   : "git://github.com/faye/faye-redis-node.git"
-                      }
+{
+    "name": "faye-redis",
+    "description": "Redis backend engine for Faye",
+    "homepage": "http://github.com/faye/faye-redis-node",
+    "author": "James Coglan <jcoglan@gmail.com> (http://jcoglan.com/)",
+    "keywords": [
+        "pubsub",
+        "bayeux"
+    ],
+    "license": "MIT",
+    "version": "0.2.0",
+    "engines": {
+        "node": ">=0.4.0"
+    },
+    "main": "./faye-redis",
+    "dependencies": {
+        "redis": "2.8.0"
+    },
+    "devDependencies": {
+        "jstest": "",
+        "mocha": "5.0.1",
+        "chai": "4.1.2",
+        "prettier": "1.16.4",
+        "hat": "0.0.3",
+        "faye": "github:smooch/faye#3240f918379fa88058a31c2a640741a8cb4cf197"
+    },
+    "scripts": {
+        "test": "node spec/runner.js",
+        "mocha": "mocha"
+    },
+    "bugs": "http://github.com/faye/faye-redis-node/issues",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/faye-redis-node.git"
+    }
 }

--- a/test/faye-redis.unit.js
+++ b/test/faye-redis.unit.js
@@ -38,8 +38,7 @@ describe('Redis engine', function() {
 
     describe('#subscribe', function() {
         it('should subscribe the client to the channel', async () => {
-            engine.subscribe(clientId, channel);
-            await utils.delay(500);
+            await new Promise((resolve) => engine.subscribe(clientId, channel, resolve));
 
             const channelIsMember = await utils.invokeAsPromise(
                 redisClient,
@@ -61,8 +60,7 @@ describe('Redis engine', function() {
         it('should add a new entry to `faye/clients` sorted set', async () => {
             const clientId = hat();
 
-            engine.subscribe(clientId, channel);
-            await utils.delay(500);
+            await new Promise((resolve) => engine.subscribe(clientId, channel, resolve));
 
             const clientScore = await utils.invokeAsPromise(redisClient, 'zscore', `${namespace}/clients`, clientId);
             expect(clientScore).to.not.be.undefined;

--- a/test/faye-redis.unit.js
+++ b/test/faye-redis.unit.js
@@ -1,0 +1,71 @@
+const { expect } = require('chai');
+const faye = require('faye');
+const hat = require('hat');
+const redis = require('redis');
+
+const fayeRedis = require('../faye-redis');
+const utils = require('./utils');
+
+describe('Redis engine', function() {
+    const namespace = 'faye';
+    let channel;
+    let clientId;
+    let engineOpts;
+    let redisClient;
+    let engine;
+    let bayeux;
+
+    before(() => {
+        redisClient = redis.createClient();
+    });
+
+    after(async () => {
+        await utils.invokeAsPromise(redisClient, 'quit');
+    });
+
+    beforeEach(() => {
+        bayeux = new faye.NodeAdapter({ mount: '/faye', timeout: 45 });
+        engine = fayeRedis.create(bayeux._server._engine, { namespace });
+
+        clientId = hat();
+        channel = hat();
+    });
+
+    afterEach(() => {
+        engine.disconnect();
+        bayeux.close();
+    });
+
+    describe('#subscribe', function() {
+        it('should subscribe the client to the channel', async () => {
+            engine.subscribe(clientId, channel);
+            await utils.delay(500);
+
+            const channelIsMember = await utils.invokeAsPromise(
+                redisClient,
+                'sismember',
+                `${namespace}/clients/${clientId}/channels`,
+                channel,
+            );
+            expect(channelIsMember).to.be.eql(1);
+
+            const clientIsMember = await utils.invokeAsPromise(
+                redisClient,
+                'sismember',
+                `${namespace}/channels${channel}`,
+                clientId,
+            );
+            expect(clientIsMember).to.be.eql(1);
+        });
+
+        it('should add a new entry to `faye/clients` sorted set', async () => {
+            const clientId = hat();
+
+            engine.subscribe(clientId, channel);
+            await utils.delay(500);
+
+            const clientScore = await utils.invokeAsPromise(redisClient, 'zscore', `${namespace}/clients`, clientId);
+            expect(clientScore).to.not.be.undefined;
+        });
+    });
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,6 +1,3 @@
-exports.delay = function(delay) {
-    return new Promise((resolve) => setTimeout(resolve, delay));
-};
 exports.invokeAsPromise = (obj, func, ...params) => {
     return new Promise((resolve, reject) => {
         obj[func](...params, (err, data) => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,14 @@
+exports.delay = function(delay) {
+    return new Promise((resolve) => setTimeout(resolve, delay));
+};
+exports.invokeAsPromise = (obj, func, ...params) => {
+    return new Promise((resolve, reject) => {
+        obj[func](...params, (err, data) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(data);
+            }
+        });
+    });
+};


### PR DESCRIPTION
Faye redis has a garbage collector that removes old clients by looking in redis at the sorted set `faye/clients`.

We observed that both leaky keys are `faye/channels/*` and `faye/client/*` so as soon as they are created (in the `subscribe` method) we also add an entry to `faye/clients`.

This PR also adds a new test suite because I was not able to run the original one.